### PR TITLE
bullhead: add missing dmservice libs

### DIFF
--- a/proprietary-blobs.txt
+++ b/proprietary-blobs.txt
@@ -98,7 +98,9 @@ lib/hw/local_time.default.so
 lib/hw/nfc_nci.bullhead.so
 lib/lib_fpc_tac_shared.so
 lib/libdmengine.so
+lib/libdmengine.so:priv-app/DMService/lib/arm/libdmengine.so
 lib/libdmjavaplugin.so
+lib/libdmjavaplugin.so:priv-app/DMService/lib/arm/libdmjavaplugin.so
 lib/libgps.utils.so
 lib/libloc_api_v02.so
 lib/libloc_core.so


### PR DESCRIPTION
These 2 files are needed by dmservice.apk and have been in the blobs
makefile but were just never added here.

Change-Id: I5f276bd5f13640a40cf6c576bb262b62d5fd24a9