### PR TITLE
bullhead: enable gesture settings

### DIFF
--- a/overlay/packages/apps/Settings/res/values/config.xml
+++ b/overlay/packages/apps/Settings/res/values/config.xml
@@ -22,4 +22,7 @@
     <!-- Enable color temperature setting. -->
     <bool name="config_enableColorTemperature">true</bool>
 
+    <!-- Enable gesture setting. -->
+    <bool name="config_gesture_settings_enabled">true</bool>
+
 </resources>


### PR DESCRIPTION
This allows the user to access Settings -> Gestures.
Currently the only way to access it is to use search.

Change-Id: Ifbf0144922ca062b5e9ec80371f44032baab4203